### PR TITLE
[feat/splash] 스플래쉬 화면 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,3 @@
-
 plugins {
     hmh("application")
     hmh("compose")
@@ -29,8 +28,12 @@ android {
 }
 
 dependencies {
+
     // Firebase
     implementation(platform(libs.firebase))
     implementation(libs.bundles.firebase)
+
+    // Splash
+    implementation(libs.splash.screen)
 
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,3 @@
-import java.util.Properties
 
 plugins {
     hmh("application")
@@ -23,7 +22,7 @@ android {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.HMHAndroid">
+            android:theme="@style/Theme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/hmh/hamyeonham/MainActivity.kt
+++ b/app/src/main/java/com/hmh/hamyeonham/MainActivity.kt
@@ -2,10 +2,34 @@ package com.hmh.hamyeonham
 
 import android.app.Activity
 import android.os.Bundle
+import android.view.animation.Animation
+import android.view.animation.AnimationUtils
+import androidx.core.splashscreen.SplashScreen
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 
 class MainActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        val splashScreen = installSplashScreen()
+        initSplashAnimation(splashScreen)
+    }
+
+    private fun initSplashAnimation(splashScreen: SplashScreen) {
+        splashScreen.setOnExitAnimationListener { splashScreenViewProvider ->
+            val splashScreenView = splashScreenViewProvider.view
+            val fadeOut = AnimationUtils.loadAnimation(this, R.anim.fade_out)
+
+            fadeOut.setAnimationListener(object : Animation.AnimationListener {
+                override fun onAnimationStart(animation: Animation) {}
+                override fun onAnimationEnd(animation: Animation) {
+                    splashScreenViewProvider.remove()
+                }
+
+                override fun onAnimationRepeat(animation: Animation) {}
+            })
+            splashScreenView.startAnimation(fadeOut)
+        }
     }
 }

--- a/app/src/main/java/com/hmh/hamyeonham/MainActivity.kt
+++ b/app/src/main/java/com/hmh/hamyeonham/MainActivity.kt
@@ -1,19 +1,20 @@
 package com.hmh.hamyeonham
 
-import android.app.Activity
 import android.os.Bundle
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 
-class MainActivity : Activity() {
+class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
 
         val splashScreen = installSplashScreen()
         initSplashAnimation(splashScreen)
+
+        setContentView(R.layout.activity_main)
     }
 
     private fun initSplashAnimation(splashScreen: SplashScreen) {

--- a/app/src/main/java/com/hmh/hamyeonham/MainActivity.kt
+++ b/app/src/main/java/com/hmh/hamyeonham/MainActivity.kt
@@ -1,9 +1,9 @@
 package com.hmh.hamyeonham
 
+import android.app.Activity
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)

--- a/app/src/main/res/anim/fade_out.xml
+++ b/app/src/main/res/anim/fade_out.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="500"
+    android:fromAlpha="1.0"
+    android:toAlpha="0.0" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.HMHAndroid" parent="Theme.AppCompat.Light.NoActionBar" />
+
+    <style name="Theme.App.Starting" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">#121212</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_background</item>
+        <item name="postSplashScreenTheme">@style/Theme.HMHAndroid</item>
+    </style>
 </resources>


### PR DESCRIPTION
## 개요
- close #13

## 작업 사항
- 스플래쉬 화면 구현

## 변경 사항(optional)
- 간단 애니메이션 적용

## 스크린샷(optional)
[Screen_recording_20231229_214825.webm](https://github.com/Team-HMH/HMH-Android/assets/83583757/3a2d8ad7-52cb-4f2f-aff2-171b0b6c9471)

---
흥 코드 가져와서 구현해보았습니다. 그런데 기존 코드로 구현 시 아래와 같은 오류가 나서 메인액티비티 파일을 AppCompatActivity 상속 받는 것에서 Activity 상속 받는 것으로 수정했더니 해결 되었습니다. 
아래 링크 참고 했는데,,,,, 사실 명확하게 오류 원인이 이해가 안되네요,,ㅜ 버전 문제인 것 같긴 한데 우리가 진행할 프로젝트 액티비티 파일에서는 어떻게 해야 하는지 궁금합니다. 흥에서는 AppCompatActivity 상속 받았던데,,,,,
```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.hmh.hamyeonham/com.hmh.hamyeonham.MainActivity}: java.lang.IllegalStateException: You need to use a Theme.AppCompat theme (or descendant) with this activity.
```
[참고 블로그](https://skysoo1111.tistory.com/25)

추가로 이후에 시간이 되면 lottie 적용도 공부해보겠습니다