### PR TITLE
[fix/logout_api_error]: logout, withdrawal header access token 넣기

### DIFF
--- a/core/network/src/main/java/com/hmh/hamyeonham/core/network/login/AuthService.kt
+++ b/core/network/src/main/java/com/hmh/hamyeonham/core/network/login/AuthService.kt
@@ -18,7 +18,9 @@ interface AuthService {
     ): BaseResponse<LoginResponse>
 
     @POST("api/v1/user/logout")
-    suspend fun logout(): BaseResponse<Unit>
+    suspend fun logout(
+        @Header("Authorization") accessToken: String,
+        ): BaseResponse<Unit>
 
     @DELETE("api/v1/user")
     suspend fun withdrawal(): BaseResponse<Unit>

--- a/core/network/src/main/java/com/hmh/hamyeonham/core/network/login/AuthService.kt
+++ b/core/network/src/main/java/com/hmh/hamyeonham/core/network/login/AuthService.kt
@@ -20,10 +20,12 @@ interface AuthService {
     @POST("api/v1/user/logout")
     suspend fun logout(
         @Header("Authorization") accessToken: String,
-        ): BaseResponse<Unit>
+    ): BaseResponse<Unit>
 
     @DELETE("api/v1/user")
-    suspend fun withdrawal(): BaseResponse<Unit>
+    suspend fun withdrawal(
+        @Header("Authorization") accessToken: String,
+    ): BaseResponse<Unit>
 
     @POST("api/v1/user/signup")
     suspend fun signUp(

--- a/core/network/src/main/java/com/hmh/hamyeonham/core/network/signup/model/SignUpResponse.kt
+++ b/core/network/src/main/java/com/hmh/hamyeonham/core/network/signup/model/SignUpResponse.kt
@@ -1,23 +1,30 @@
 package com.hmh.hamyeonham.core.network.signup.model
 
+import com.hmh.hamyeonham.core.network.login.model.LoginResponse
 import com.hmh.hamyeonham.login.model.SignUpUser
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class SignUpResponse(
-    @SerialName("accessToken")
-    val accessToken: String,
-    @SerialName("refreshToken")
-    val refreshToken: String,
+    @SerialName("token")
+    val token: LoginResponse.Token? = null,
     @SerialName("userId")
     val userId: Int,
 ) {
+    @Serializable
+    data class Token(
+        @SerialName("accessToken")
+        val accessToken: String? = null,
+        @SerialName("refreshToken")
+        val refreshToken: String? = null,
+    )
+
     fun toSignUpUser(): SignUpUser {
         return SignUpUser(
             userId = userId,
-            accessToken = accessToken,
-            refreshToken = refreshToken,
+            accessToken = token?.accessToken.orEmpty(),
+            refreshToken = token?.refreshToken.orEmpty(),
         )
     }
 }

--- a/data/login/src/main/java/com/hmh/hamyeonham/login/DefaultAuthRepository.kt
+++ b/data/login/src/main/java/com/hmh/hamyeonham/login/DefaultAuthRepository.kt
@@ -43,9 +43,10 @@ class DefaultAuthRepository @Inject constructor(
         }
     }
 
-    override suspend fun withdrawal(): Result<Unit> {
+    override suspend fun withdrawal(accessToken: String): Result<Unit> {
+        val bearerToken = "Bearer $accessToken"
         return runCatching {
-            authService.withdrawal()
+            authService.withdrawal(bearerToken)
         }
     }
 }

--- a/data/login/src/main/java/com/hmh/hamyeonham/login/DefaultAuthRepository.kt
+++ b/data/login/src/main/java/com/hmh/hamyeonham/login/DefaultAuthRepository.kt
@@ -36,9 +36,10 @@ class DefaultAuthRepository @Inject constructor(
         }
     }
 
-    override suspend fun logout(): Result<Unit> {
+    override suspend fun logout(accessToken: String): Result<Unit> {
+        val bearerToken = "Bearer $accessToken"
         return runCatching {
-            authService.logout()
+            authService.logout(bearerToken)
         }
     }
 

--- a/data/login/src/main/java/com/hmh/hamyeonham/login/mapper/SignUpMapper.kt
+++ b/data/login/src/main/java/com/hmh/hamyeonham/login/mapper/SignUpMapper.kt
@@ -1,11 +1,14 @@
 package com.hmh.hamyeonham.login.mapper
 
+import com.hmh.hamyeonham.core.network.login.model.LoginResponse
 import com.hmh.hamyeonham.core.network.signup.model.SignUpResponse
 
 internal fun SignUpResponse.toSignUp(): SignUpResponse {
     return SignUpResponse(
         userId = userId ?: -1,
-        accessToken = accessToken.orEmpty(),
-        refreshToken = refreshToken.orEmpty(),
+        token = LoginResponse.Token(
+            accessToken = token?.accessToken.orEmpty(),
+            refreshToken = token?.refreshToken.orEmpty(),
+        ),
     )
 }

--- a/domain/login/src/main/java/com/hmh/hamyeonham/login/repository/AuthRepository.kt
+++ b/domain/login/src/main/java/com/hmh/hamyeonham/login/repository/AuthRepository.kt
@@ -6,7 +6,7 @@ import com.hmh.hamyeonham.login.model.SignUpUser
 
 interface AuthRepository {
     suspend fun login(accessToken: String): Result<Login>
-    suspend fun logout(): Result<Unit>
+    suspend fun logout(accessToken: String): Result<Unit>
     suspend fun signUp(accessToken: String, signUpRequest: SignRequestDomain): Result<SignUpUser>
     suspend fun withdrawal(): Result<Unit>
 }

--- a/domain/login/src/main/java/com/hmh/hamyeonham/login/repository/AuthRepository.kt
+++ b/domain/login/src/main/java/com/hmh/hamyeonham/login/repository/AuthRepository.kt
@@ -8,5 +8,5 @@ interface AuthRepository {
     suspend fun login(accessToken: String): Result<Login>
     suspend fun logout(accessToken: String): Result<Unit>
     suspend fun signUp(accessToken: String, signUpRequest: SignRequestDomain): Result<SignUpUser>
-    suspend fun withdrawal(): Result<Unit>
+    suspend fun withdrawal(accessToken: String): Result<Unit>
 }

--- a/feature/login/src/main/java/com/hmh/hamyeonham/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/hmh/hamyeonham/feature/login/LoginViewModel.kt
@@ -57,10 +57,12 @@ class LoginViewModel @Inject constructor(
                 } else if (token != null) {
                     viewModelScope.launch {
                         authRepository.login(token.accessToken).onSuccess {
-                            hmhNetworkPreference.accessToken = it.accessToken
-                            hmhNetworkPreference.refreshToken = it.refreshToken
-                            hmhNetworkPreference.userId = it.userId
-                            hmhNetworkPreference.autoLoginConfigured = true
+                            hmhNetworkPreference.run {
+                                accessToken = it.accessToken
+                                refreshToken = it.refreshToken
+                                userId = it.userId
+                                autoLoginConfigured = true
+                            }
                             _kakaoLoginEvent.emit(LoginEffect.LoginSuccess)
                         }.onFailure {
                             if (it is HttpException && it.code() == 403) {

--- a/feature/mypage/src/main/java/com/hmh/hamyeonham/mypage/viewmodel/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/hmh/hamyeonham/mypage/viewmodel/MyPageViewModel.kt
@@ -31,11 +31,12 @@ class MyPageViewModel @Inject constructor(
 
     fun handleLogout() {
         viewModelScope.launch {
-            authRepository.logout().onSuccess {
+            authRepository.logout(hmhPreferenceAccessToken.accessToken).onSuccess {
                 _userEffect.emit(UserEffect.logoutSuccess)
                 hmhPreferenceAccessToken.clear()
                 Log.d("hmhPreferenceAccessToken", hmhPreferenceAccessToken.accessToken)
             }.onFailure {
+                Log.d("FAIL : hmhPreferenceAccessToken", hmhPreferenceAccessToken.accessToken)
                 _userEffect.emit(UserEffect.logoutFail)
             }
         }

--- a/feature/mypage/src/main/java/com/hmh/hamyeonham/mypage/viewmodel/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/hmh/hamyeonham/mypage/viewmodel/MyPageViewModel.kt
@@ -43,8 +43,8 @@ class MyPageViewModel @Inject constructor(
     fun handleWithdrawal() {
         viewModelScope.launch {
             authRepository.withdrawal(hmhPreferenceAccessToken.accessToken).onSuccess {
-                _userEffect.emit(UserEffect.withdrawalSuccess)
                 hmhPreferenceAccessToken.clear()
+                _userEffect.emit(UserEffect.withdrawalSuccess)
                 Log.d("hmhPreferenceAccessToken", hmhPreferenceAccessToken.accessToken)
             }.onFailure {
                 _userEffect.emit(UserEffect.withdrawalFail)

--- a/feature/mypage/src/main/java/com/hmh/hamyeonham/mypage/viewmodel/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/hmh/hamyeonham/mypage/viewmodel/MyPageViewModel.kt
@@ -34,9 +34,7 @@ class MyPageViewModel @Inject constructor(
             authRepository.logout(hmhPreferenceAccessToken.accessToken).onSuccess {
                 _userEffect.emit(UserEffect.logoutSuccess)
                 hmhPreferenceAccessToken.clear()
-                Log.d("hmhPreferenceAccessToken", hmhPreferenceAccessToken.accessToken)
             }.onFailure {
-                Log.d("FAIL : hmhPreferenceAccessToken", hmhPreferenceAccessToken.accessToken)
                 _userEffect.emit(UserEffect.logoutFail)
             }
         }
@@ -44,7 +42,7 @@ class MyPageViewModel @Inject constructor(
 
     fun handleWithdrawal() {
         viewModelScope.launch {
-            authRepository.withdrawal().onSuccess {
+            authRepository.withdrawal(hmhPreferenceAccessToken.accessToken).onSuccess {
                 _userEffect.emit(UserEffect.withdrawalSuccess)
                 hmhPreferenceAccessToken.clear()
                 Log.d("hmhPreferenceAccessToken", hmhPreferenceAccessToken.accessToken)

--- a/feature/onboarding/src/main/java/com/hmh/hamyeonham/feature/onboarding/OnBoardingActivity.kt
+++ b/feature/onboarding/src/main/java/com/hmh/hamyeonham/feature/onboarding/OnBoardingActivity.kt
@@ -10,8 +10,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2.OFFSCREEN_PAGE_LIMIT_DEFAULT
 import com.hmh.hamyeonham.common.view.viewBinding
 import com.hmh.hamyeonham.feature.onboarding.databinding.ActivityOnBoardingBinding
-import com.hmh.hamyeonham.feature.onboarding.viewmodel.OnBoardingEffect
 import com.hmh.hamyeonham.feature.onboarding.viewmodel.OnBoardingViewModel
+import com.hmh.hamyeonham.feature.onboarding.viewmodel.SignUpEffect
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -32,11 +32,25 @@ class OnBoardingActivity : AppCompatActivity() {
         initViews()
         setBackPressedCallback()
         collectOnboardingState()
+        collectSignUpEffect()
 
         val accessToken = intent.getStringExtra(EXTRA_ACCESS_TOKEN)
         viewModel.updateState {
             copy(accessToken = accessToken.orEmpty())
         }
+    }
+
+    private fun collectSignUpEffect() {
+        viewModel.onboardEffect.flowWithLifecycle(lifecycle).onEach {
+            when (it) {
+                is SignUpEffect.SignUpSuccess -> {
+                    moveToOnBoardingDoneSignUpActivity()
+                }
+
+                is SignUpEffect.SignUpFail -> {
+                }
+            }
+        }.launchIn(lifecycleScope)
     }
 
     private fun initViews() {
@@ -82,15 +96,6 @@ class OnBoardingActivity : AppCompatActivity() {
 
                 currentItem == lastItem -> {
                     viewModel.signUp()
-                    viewModel.onboardEffect.flowWithLifecycle(lifecycle).onEach {
-                        when (it) {
-                            is OnBoardingEffect.SignUpSuccess -> {
-                                moveToOnBoardingDoneSignUpActivity()
-                            }
-                            is OnBoardingEffect.SignUpFail -> {
-                            }
-                        }
-                    }.launchIn(lifecycleScope)
                 }
 
                 else -> Unit

--- a/feature/onboarding/src/main/java/com/hmh/hamyeonham/feature/onboarding/OnBoardingActivity.kt
+++ b/feature/onboarding/src/main/java/com/hmh/hamyeonham/feature/onboarding/OnBoardingActivity.kt
@@ -2,7 +2,6 @@ package com.hmh.hamyeonham.feature.onboarding
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -14,7 +13,6 @@ import com.hmh.hamyeonham.feature.onboarding.databinding.ActivityOnBoardingBindi
 import com.hmh.hamyeonham.feature.onboarding.viewmodel.OnBoardingEffect
 import com.hmh.hamyeonham.feature.onboarding.viewmodel.OnBoardingViewModel
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -83,25 +81,21 @@ class OnBoardingActivity : AppCompatActivity() {
                 }
 
                 currentItem == lastItem -> {
-                    startSignupApi()
+                    viewModel.signUp()
+                    viewModel.onboardEffect.flowWithLifecycle(lifecycle).onEach {
+                        when (it) {
+                            is OnBoardingEffect.SignUpSuccess -> {
+                                moveToOnBoardingDoneSignUpActivity()
+                            }
+                            is OnBoardingEffect.SignUpFail -> {
+                            }
+                        }
+                    }.launchIn(lifecycleScope)
                 }
+
                 else -> Unit
             }
         }
-    }
-
-    private fun startSignupApi(): Job {
-        viewModel.signUp()
-        return viewModel.onboardEffect.flowWithLifecycle(lifecycle).onEach {
-            when (it) {
-                is OnBoardingEffect.SignUpSuccess -> {
-                    moveToOnBoardingDoneSignUpActivity()
-                }
-
-                is OnBoardingEffect.SignUpFail -> {
-                }
-            }
-        }.launchIn(lifecycleScope)
     }
 
     private fun collectOnboardingState() {
@@ -141,7 +135,6 @@ class OnBoardingActivity : AppCompatActivity() {
     private fun updateProgressBar(currentItem: Int, totalItems: Int) {
         val progress = (currentItem + 1).toFloat() / totalItems.toFloat()
         val progressBarWidth = (progress * 100).toInt()
-        Log.d("progressBarWidth", progressBarWidth.toString())
         binding.pbOnboarding.progress = progressBarWidth
     }
 

--- a/feature/onboarding/src/main/java/com/hmh/hamyeonham/feature/onboarding/viewmodel/OnBoardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/hmh/hamyeonham/feature/onboarding/viewmodel/OnBoardingViewModel.kt
@@ -15,9 +15,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-sealed interface OnBoardingEffect {
-    data object SignUpSuccess : OnBoardingEffect
-    data object SignUpFail : OnBoardingEffect
+sealed interface SignUpEffect {
+    data object SignUpSuccess : SignUpEffect
+    data object SignUpFail : SignUpEffect
 }
 
 data class OnBoardingState(
@@ -38,7 +38,7 @@ class OnBoardingViewModel @Inject constructor(
     private val _onBoardingState = MutableStateFlow(OnBoardingState())
     val onBoardingState = _onBoardingState.asStateFlow()
 
-    private val _onboardEffect = MutableSharedFlow<OnBoardingEffect>()
+    private val _onboardEffect = MutableSharedFlow<SignUpEffect>()
     val onboardEffect = _onboardEffect.asSharedFlow()
 
     init {
@@ -82,11 +82,11 @@ class OnBoardingViewModel @Inject constructor(
                     hmhNetworkPreference.autoLoginConfigured = true
                 }
                 viewModelScope.launch {
-                    _onboardEffect.emit(OnBoardingEffect.SignUpSuccess)
+                    _onboardEffect.emit(SignUpEffect.SignUpSuccess)
                 }
             }.onFailure {
                 viewModelScope.launch {
-                    _onboardEffect.emit(OnBoardingEffect.SignUpFail)
+                    _onboardEffect.emit(SignUpEffect.SignUpFail)
                 }
             }
         }

--- a/feature/onboarding/src/main/java/com/hmh/hamyeonham/feature/onboarding/viewmodel/OnBoardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/hmh/hamyeonham/feature/onboarding/viewmodel/OnBoardingViewModel.kt
@@ -71,24 +71,22 @@ class OnBoardingViewModel @Inject constructor(
         viewModelScope.launch {
             val token = onBoardingState.value.accessToken
             val request = onBoardingState.value.onBoardingAnswer
-            runCatching {
-                authRepository.signUp(token, request.toSignUpRequest())
-            }.onSuccess { result ->
-                val signUpUser = result.getOrNull()
-                signUpUser?.let {
-                    hmhNetworkPreference.accessToken = it.accessToken
-                    hmhNetworkPreference.refreshToken = it.refreshToken
-                    hmhNetworkPreference.userId = it.userId
-                    hmhNetworkPreference.autoLoginConfigured = true
+            authRepository.signUp(token, request.toSignUpRequest())
+                .onSuccess { signUpUser ->
+                    signUpUser.let {
+                        hmhNetworkPreference.accessToken = it.accessToken
+                        hmhNetworkPreference.refreshToken = it.refreshToken
+                        hmhNetworkPreference.userId = it.userId
+                        hmhNetworkPreference.autoLoginConfigured = true
+                    }
+                    viewModelScope.launch {
+                        _onboardEffect.emit(SignUpEffect.SignUpSuccess)
+                    }
+                }.onFailure {
+                    viewModelScope.launch {
+                        _onboardEffect.emit(SignUpEffect.SignUpFail)
+                    }
                 }
-                viewModelScope.launch {
-                    _onboardEffect.emit(SignUpEffect.SignUpSuccess)
-                }
-            }.onFailure {
-                viewModelScope.launch {
-                    _onboardEffect.emit(SignUpEffect.SignUpFail)
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
## 개요
- close #124 

## 작업 사항
- logout, withdrawal header access token 이 없는 채로 통신 중 에러 발생으로 access token 넣는 로직으로 수정했습니다.

## 변경 사항(optional)
- logout, withdrawal API 연관 코드 수정되었습니다.

## 스크린샷(optional)
- 내용을 적어주세요.
