### PR TITLE
[feat/lock_UI_design]: LockScreen 변경된 UI로 수정

### DIFF
--- a/feature/lock/src/main/AndroidManifest.xml
+++ b/feature/lock/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
         <activity
             android:name=".LockActivity"
             android:exported="false"
-            android:theme="@style/Base.Theme.HMH" />
+            android:theme="@style/Base.Theme.HMH"
+            android:screenOrientation="portrait" />
 
         <service
             android:name="com.hmh.hamyeonham.core.service.LockAccessibilityService"

--- a/feature/lock/src/main/java/com/hmh/hamyeonham/feature/lock/LockActivity.kt
+++ b/feature/lock/src/main/java/com/hmh/hamyeonham/feature/lock/LockActivity.kt
@@ -14,15 +14,18 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Shapes
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.hmh.hamyeonham.common.context.getAppNameFromPackageName
@@ -100,14 +103,15 @@ fun LockScreen(
 
         Column(
             modifier = Modifier
-                .align(Alignment.Center)
-                .fillMaxWidth(),
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .padding(top = 132.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             AsyncImage(
                 model = R.drawable.lock_on,
                 contentDescription = "LockScreen Icon",
-                modifier = Modifier.padding(bottom = 48.dp),
+                modifier = Modifier.padding(bottom = 48.dp).size(120.dp),
             )
             Text(
                 text = stringResource(R.string.target_usage_time_end),
@@ -117,7 +121,7 @@ fun LockScreen(
             Text(
                 stringResource(R.string.use_it_anymore, appName),
                 color = Gray2,
-                style = HmhTypography.bodyMedium,
+                style = TextStyle(textAlign = TextAlign.Center).merge(HmhTypography.bodyMedium),
                 modifier = Modifier.padding(vertical = 10.dp),
             )
         }
@@ -130,7 +134,7 @@ fun LockScreen(
         ) {
             Text(
                 stringResource(R.string.remind_alarm_permission),
-                style = HmhTypography.bodySmall,
+                style = TextStyle(textAlign = TextAlign.Center).merge(HmhTypography.bodySmall),
                 color = Gray3,
                 modifier = Modifier.padding(vertical = 21.dp).align(Alignment.CenterHorizontally),
             )
@@ -139,7 +143,7 @@ fun LockScreen(
                 onClick = {
                     onClickClose()
                 },
-                shape = Shapes().medium,
+                shape = RoundedCornerShape(4.dp),
                 modifier = Modifier.padding(vertical = 14.dp),
             ) {
                 Text(
@@ -151,7 +155,8 @@ fun LockScreen(
                 )
             }
             Text(
-                modifier = Modifier.clickable(onClick = onClickUnLock).padding(vertical = 38.dp),
+                modifier = Modifier.clickable(onClick = onClickUnLock)
+                    .padding(top = 22.dp, bottom = 58.dp),
                 text = stringResource(R.string.do_unlock),
                 style = HmhTypography.titleSmall,
                 color = Gray1,

--- a/feature/lock/src/main/java/com/hmh/hamyeonham/feature/lock/LockActivity.kt
+++ b/feature/lock/src/main/java/com/hmh/hamyeonham/feature/lock/LockActivity.kt
@@ -11,32 +11,31 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Shapes
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.hmh.hamyeonham.common.context.getAppNameFromPackageName
 import com.hmh.hamyeonham.common.context.toast
 import com.hmh.hamyeonham.common.navigation.NavigationProvider
 import com.hmh.hamyeonham.feature.lock.ui.theme.Blackground
+import com.hmh.hamyeonham.feature.lock.ui.theme.BluePurpleButton
+import com.hmh.hamyeonham.feature.lock.ui.theme.Gray1
+import com.hmh.hamyeonham.feature.lock.ui.theme.Gray2
+import com.hmh.hamyeonham.feature.lock.ui.theme.Gray3
 import com.hmh.hamyeonham.feature.lock.ui.theme.HMHAndroidTheme
 import com.hmh.hamyeonham.feature.lock.ui.theme.HmhTypography
+import com.hmh.hamyeonham.feature.lock.ui.theme.WhiteBtn
 import com.hmh.hamyeonham.feature.lock.ui.theme.WhiteText
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -55,7 +54,7 @@ class LockActivity : ComponentActivity() {
                     onClickClose = {
                         killAppByPackageName(
                             context = this,
-                            packageName = packageName
+                            packageName = packageName,
                         )
                         finish()
                     },
@@ -66,7 +65,7 @@ class LockActivity : ComponentActivity() {
                             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                         }.let(::startActivity)
                         finish()
-                    }
+                    },
                 )
             }
         }
@@ -85,7 +84,6 @@ class LockActivity : ComponentActivity() {
     }
 }
 
-
 @Composable
 fun LockScreen(
     packageName: String,
@@ -95,42 +93,32 @@ fun LockScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Blackground)
+            .background(Blackground),
     ) {
         val context = LocalContext.current
         val appName = context.getAppNameFromPackageName(packageName)
-        val appIcon = context.packageManager.getApplicationIcon(packageName)
 
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
                 .fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             AsyncImage(
-                model = appIcon,
-                contentDescription = "App Image"
+                model = R.drawable.lock_on,
+                contentDescription = "LockScreen Icon",
+                modifier = Modifier.padding(bottom = 48.dp),
             )
-            Spacer(modifier = Modifier.height(44.dp))
             Text(
                 text = stringResource(R.string.target_usage_time_end),
-                fontSize = 20.sp,
-                style = TextStyle(
-                    fontSize = 20.sp,
-                    lineHeight = 30.sp,
-                    fontWeight = FontWeight(600),
-                    color = Color(0xFFDBDAE7),
-                )
+                style = HmhTypography.headlineMedium,
+                color = WhiteText,
             )
-            Spacer(modifier = Modifier.height(5.dp))
             Text(
                 stringResource(R.string.use_it_anymore, appName),
-                style = TextStyle(
-                    fontSize = 14.sp,
-                    lineHeight = 21.sp,
-                    fontWeight = FontWeight(400),
-                    color = Color(0xFF8D8D9F),
-                )
+                color = Gray2,
+                style = HmhTypography.bodyMedium,
+                modifier = Modifier.padding(vertical = 10.dp),
             )
         }
 
@@ -138,29 +126,36 @@ fun LockScreen(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            Text(
+                stringResource(R.string.remind_alarm_permission),
+                style = HmhTypography.bodySmall,
+                color = Gray3,
+                modifier = Modifier.padding(vertical = 21.dp).align(Alignment.CenterHorizontally),
+            )
             Button(
-                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF3D17D3)),
+                colors = ButtonDefaults.buttonColors(containerColor = BluePurpleButton),
                 onClick = {
                     onClickClose()
                 },
+                shape = Shapes().medium,
+                modifier = Modifier.padding(vertical = 14.dp),
             ) {
                 Text(
                     text = stringResource(R.string.close),
                     modifier = Modifier
                         .padding(horizontal = 70.dp, vertical = 10.dp),
-                    style = HmhTypography.titleMedium
+                    style = HmhTypography.titleMedium,
+                    color = WhiteBtn,
                 )
             }
-            Spacer(modifier = Modifier.height(14.dp))
             Text(
-                modifier = Modifier.clickable(onClick = onClickUnLock),
+                modifier = Modifier.clickable(onClick = onClickUnLock).padding(vertical = 38.dp),
                 text = stringResource(R.string.do_unlock),
                 style = HmhTypography.titleSmall,
-                color = WhiteText
+                color = Gray1,
             )
-            Spacer(modifier = Modifier.height(38.dp))
         }
     }
 }
@@ -173,13 +168,5 @@ fun killAppByPackageName(context: Context, packageName: String) {
     } catch (e: Exception) {
         context.toast(context.getString(R.string.app_kill_fail))
         Log.e("LockActivity", "killAppByPackageName error : $e")
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    HMHAndroidTheme {
-        LockScreen("HHM")
     }
 }

--- a/feature/lock/src/main/res/drawable/lock_on.xml
+++ b/feature/lock/src/main/res/drawable/lock_on.xml
@@ -1,0 +1,127 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="120dp"
+    android:height="120dp"
+    android:viewportWidth="120"
+    android:viewportHeight="120">
+  <path
+      android:pathData="M86.4,117.86H33.18L15.01,98.41V44.07H104.57V98.41L86.4,117.86Z"
+      android:fillColor="#3427EE"/>
+  <path
+      android:pathData="M86.4,117.86H33.18C26.09,110.26 22.11,106 15.01,98.41V44.07L33.18,41.8H86.4L104.57,44.07V98.41C97.48,106 93.5,110.25 86.4,117.85V117.86Z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="59.79"
+          android:startY="41.8"
+          android:endX="59.79"
+          android:endY="117.86"
+          android:type="linear">
+        <item android:offset="0" android:color="#FF3D17D3"/>
+        <item android:offset="1" android:color="#FF5C8DFF"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M64.71,66.87H54.87V92.8H64.71V66.87Z"
+      android:fillColor="#17171B"/>
+  <path
+      android:pathData="M86.39,41.8H33.18L15.01,44.07L33.18,46.35H86.4L104.57,44.07L86.39,41.8Z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="15.01"
+          android:startY="44.07"
+          android:endX="104.57"
+          android:endY="44.07"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFFFCDDD"/>
+        <item android:offset="0.9" android:color="#00FFCDDD"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M74.05,2.15H45.53L27.61,20.07V43.68L30.76,44.15H41.26V25.72L51.18,15.8H68.4L78.32,25.72V44.15H88.82L91.97,43.68V20.07L74.05,2.15Z"
+      android:fillColor="#3D17D3"/>
+  <path
+      android:pathData="M27.61,20.07L30.76,21.37L46.84,5.3L45.53,2.15L27.61,20.07Z"
+      android:fillColor="#DFDFF1"/>
+  <path
+      android:pathData="M45.53,2.15L46.84,5.3H72.75L74.05,2.15H45.53Z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="45.53"
+          android:startY="3.72"
+          android:endX="74.05"
+          android:endY="3.72"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFFFCDDD"/>
+        <item android:offset="0.9" android:color="#00FFCDDD"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M27.61,43.68L30.76,44.15V21.37L27.61,20.07V43.68Z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="22.62"
+          android:startY="38.69"
+          android:endX="35.34"
+          android:endY="25.95"
+          android:type="linear">
+        <item android:offset="0.1" android:color="#00FFCDDD"/>
+        <item android:offset="1" android:color="#FFFFCDDD"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M33.18,117.86V46.35L15.01,44.07V98.41L33.18,117.86Z"
+      android:fillColor="#5C8DFF"/>
+  <path
+      android:pathData="M86.4,117.86V46.35L104.57,44.07V98.41L86.4,117.86Z"
+      android:fillColor="#2C16A3"/>
+  <path
+      android:pathData="M33.18,117.86V46.35L15.01,44.07V98.41L33.18,117.86Z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="10.19"
+          android:startY="94.86"
+          android:endX="45.95"
+          android:endY="59.11"
+          android:type="linear">
+        <item android:offset="0.1" android:color="#003D17D3"/>
+        <item android:offset="1" android:color="#FF3D17D3"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M78.32,25.72L80.6,24.64V44.15H78.32V25.72Z"
+      android:strokeAlpha="0.3"
+      android:fillAlpha="0.3">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="79.46"
+          android:startY="24.64"
+          android:endX="79.46"
+          android:endY="44.15"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFFFCDDD"/>
+        <item android:offset="0.9" android:color="#00FFCDDD"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M33.18,117.86V46.35L15.01,44.07V98.41L33.18,117.86Z"
+      android:strokeAlpha="0.3"
+      android:fillAlpha="0.3">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="10.19"
+          android:startY="94.86"
+          android:endX="45.95"
+          android:endY="59.11"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFFFCDDD"/>
+        <item android:offset="0.9" android:color="#00FFCDDD"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+</vector>

--- a/feature/lock/src/main/res/values/strings.xml
+++ b/feature/lock/src/main/res/values/strings.xml
@@ -3,5 +3,6 @@
     <string name="use_it_anymore">이제 %s을(를)\n"사용할 수 없어요"</string>
     <string name="close">닫기</string>
     <string name="do_unlock">잠금 해제하기</string>
-    <string name="app_kill_fail">앱을 종료하는데 실패했습니다.</string>
+    <string name="app_kill_fail">앱을 종료하는 데 실패했습니다.</string>
+    <string name="remind_alarm_permission">*알림이 오지 않는다면\n설정에서 푸시 알림 권한을 허용해 주세요</string>
 </resources>


### PR DESCRIPTION
## 개요
- close #168 

## 작업 사항
- LockScreen 변경된 UI로 수정

## 변경 사항(optional)
- 불필요하다고 생각된 spacer를 모두 제거하고, 컴포넌트 간 padding으로 교체했습니다
- 디자인 시스템이 적용 안 된 곳 모두 디자인 시스템 활용하도록 수정했습니다
- 기존에 자물쇠 이미지가 아닌 앱 이미지로 되어 있던 것 변경된 이미지로 수정했습니다 -> 앱 이미지 변수 삭제함
- 권한 허용 리마인드 텍스트 추가 되었습니다
- 자잘한 디자인 수정 모두 반영했습니다
- 가로모드 불필요한 화면 같아서 막았습니다

## 스크린샷(optional)
|변경된 디자인|
|:---------:|
![image](https://github.com/Team-HMH/HMH-Android/assets/83583757/2b5f40ae-1ebf-44b9-8deb-e1fac6f7a7d1)