### PR TITLE
[feat]: 챌린지 앱 편집 UI 수정

### DIFF
--- a/app/src/main/java/com/hmh/hamyeonham/SampleActivity.kt
+++ b/app/src/main/java/com/hmh/hamyeonham/SampleActivity.kt
@@ -7,12 +7,9 @@ import android.view.animation.AnimationUtils
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import com.hmh.hamyeonham.challenge.appadd.AppAddActivity
 import com.hmh.hamyeonham.common.view.viewBinding
 import com.hmh.hamyeonham.databinding.ActivitySampleBinding
 import com.hmh.hamyeonham.feature.login.LoginActivity
-import com.hmh.hamyeonham.feature.main.MainActivity
-import com.hmh.hamyeonham.feature.onboarding.OnBoardingActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -24,7 +21,7 @@ class SampleActivity : AppCompatActivity() {
         val splashScreen = installSplashScreen()
         initSplashAnimation(splashScreen)
         setContentView(binding.root)
-        startActivity(Intent(this, AppAddActivity::class.java))
+        startActivity(Intent(this, LoginActivity::class.java))
         finish()
     }
 

--- a/app/src/main/java/com/hmh/hamyeonham/SampleActivity.kt
+++ b/app/src/main/java/com/hmh/hamyeonham/SampleActivity.kt
@@ -7,6 +7,7 @@ import android.view.animation.AnimationUtils
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import com.hmh.hamyeonham.challenge.appadd.AppAddActivity
 import com.hmh.hamyeonham.common.view.viewBinding
 import com.hmh.hamyeonham.databinding.ActivitySampleBinding
 import com.hmh.hamyeonham.feature.login.LoginActivity
@@ -23,7 +24,7 @@ class SampleActivity : AppCompatActivity() {
         val splashScreen = installSplashScreen()
         initSplashAnimation(splashScreen)
         setContentView(binding.root)
-        startActivity(Intent(this, LoginActivity::class.java))
+        startActivity(Intent(this, AppAddActivity::class.java))
         finish()
     }
 

--- a/feature/challenge/src/main/res/layout/activity_app_add.xml
+++ b/feature/challenge/src/main/res/layout/activity_app_add.xml
@@ -22,14 +22,24 @@
             app:layout_constraintDimensionRatio="1"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:text="@string/app_add_top_bar"
+            android:textAppearance="?textAppearanceTitleLarge"
+            android:textColor="@color/white_text"
+            app:layout_constraintBottom_toBottomOf="@+id/iv_back"
+            app:layout_constraintStart_toEndOf="@+id/iv_back"
+            app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/vp_app_add"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginBottom="16dp"
-        app:layout_constraintBottom_toTopOf="@id/bt_app_selection"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/cl_top_appbar" />
@@ -39,7 +49,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="20dp"
-        android:layout_marginTop="16dp"
         android:layout_marginBottom="22dp"
         android:background="@drawable/selector_app_selection_btn"
         android:enabled="false"
@@ -47,5 +56,21 @@
         android:text="@string/app_selection_done"
         android:textAppearance="?textAppearanceTitleMedium"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/vp_app_add" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/cl_bottom"
+        android:layout_width="match_parent"
+        android:layout_height="22dp"
+        android:alpha="1"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/bt_app_selection"
+        android:background="#8017171B"
+        />
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/challenge/src/main/res/layout/activity_app_add.xml
+++ b/feature/challenge/src/main/res/layout/activity_app_add.xml
@@ -23,16 +23,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
-            android:text="@string/app_add_top_bar"
-            android:textAppearance="?textAppearanceTitleLarge"
-            android:textColor="@color/white_text"
-            app:layout_constraintBottom_toBottomOf="@+id/iv_back"
-            app:layout_constraintStart_toEndOf="@+id/iv_back"
-            app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.viewpager2.widget.ViewPager2

--- a/feature/challenge/src/main/res/values/strings.xml
+++ b/feature/challenge/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="challenge_create_title">새로운 여정을 위한\n챌린지를 생성해 주세요</string>
     <string name="challenge_create">챌린지 생성하기</string>
     <string name="all_time"> 시간</string>
+    <string name="app_add_top_bar">앱 편집</string>
 </resources>

--- a/feature/challenge/src/main/res/values/strings.xml
+++ b/feature/challenge/src/main/res/values/strings.xml
@@ -10,5 +10,4 @@
     <string name="challenge_create_title">새로운 여정을 위한\n챌린지를 생성해 주세요</string>
     <string name="challenge_create">챌린지 생성하기</string>
     <string name="all_time"> 시간</string>
-    <string name="app_add_top_bar">앱 편집</string>
 </resources>


### PR DESCRIPTION
## 개요
- close #171 

## 작업 사항
- 버튼 하단까지 앱 리스트 영역 넓힘 + 투명도 설정
- topBar에 앱 편집 텍스트 추가

## 변경 사항(optional)
- 목표 시간 설정도 같은 액티비티라 어쩔 수 없이 topbar 텍스트가 들어가는데, 디자인과 논의 필요합니다
- 버튼 밑까지 리스트 넓혔는데 이 뷰만 투명도가 적용돼 있어서.. 어떻게 할까 하다가 그냥.. 투명한 색의 레이아웃을 추가했습니다
- 버튼 시간 설정 뷰에서 텍스트 수정도 필요합니답

## 스크린샷(optional)
![image](https://github.com/Team-HMH/HMH-Android/assets/83583757/098cc192-4f8f-4fb2-a11f-cff10aca773d)
![image](https://github.com/Team-HMH/HMH-Android/assets/83583757/b9926aac-3cfe-4022-ba17-471233f020db)
