### PR TITLE
[feat/feat/active_onboarding_challenge_date]: 챌린지 기간 21, 30일 불가능 했던 것 가능하게 추가

### DIFF
--- a/feature/onboarding/src/main/java/com/hmh/hamyeonham/feature/onboarding/fragment/OnBoardingSelectDataFragment.kt
+++ b/feature/onboarding/src/main/java/com/hmh/hamyeonham/feature/onboarding/fragment/OnBoardingSelectDataFragment.kt
@@ -9,8 +9,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
-import com.hmh.hamyeonham.common.fragment.colorOf
-import com.hmh.hamyeonham.common.fragment.drawableOf
 import com.hmh.hamyeonham.common.primitive.extractDigits
 import com.hmh.hamyeonham.common.view.viewBinding
 import com.hmh.hamyeonham.feature.onboarding.R
@@ -101,18 +99,6 @@ class OnBoardingSelectDataFragment : Fragment() {
     private fun initFragmentType() {
         fragmentType?.let {
             viewModel.initQuestionData(it)
-            if (it == OnBoardingFragmentType.SELECT_DATA_PERIOD) {
-                binding.run {
-                    btnOnboardingSelectData3.isEnabled = false
-                    btnOnboardingSelectData4.isEnabled = false
-                    btnOnboardingSelectData3.background =
-                        drawableOf(R.drawable.onboarding_select_data_disable)
-                    btnOnboardingSelectData4.background =
-                        drawableOf(R.drawable.onboarding_select_data_disable)
-                    btnOnboardingSelectData3.setTextColor(colorOf(com.hmh.hamyeonham.core.designsystem.R.color.gray5))
-                    btnOnboardingSelectData4.setTextColor(colorOf(com.hmh.hamyeonham.core.designsystem.R.color.gray5))
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## 개요
- close #183 

## 작업 사항
- 챌린지 기간 21, 30일 불가능 했던 것 가능하게 추가

## 변경 사항(optional)
- 뷰에서 클릭을 못하게 막아두었던 것이고, state는 text를 int로 변경해서 보내도록 했어서 클릭 가능하게만 수정해도 챌린지 21, 30일 선택이 가능합니다
- 우선 온보딩 쪽에서는 21, 30일 챌린지가 가능하게 되었는데, 캘린더 어댑터 쪽도 21, 30일 뷰 반환이 가능한지 확인 필요합니다

## 스크린샷(optional)
![image](https://github.com/Team-HMH/HMH-Android/assets/83583757/33e25d00-e85b-4371-90a5-acc08d063d72)
![image](https://github.com/Team-HMH/HMH-Android/assets/83583757/4a75a2c3-666a-46c1-8433-e6d57a4547fc)
